### PR TITLE
replace None odometer with logs

### DIFF
--- a/src/carconnectivity_connectors/volkswagen_na/connector.py
+++ b/src/carconnectivity_connectors/volkswagen_na/connector.py
@@ -649,7 +649,8 @@ class Connector(BaseConnector):
                 log_extra_keys(LOG_API, 'measurements', data['measurements'], {'fuelLevelStatus', 'odometerStatus', 'temperatureOutsideStatus',
                                                                                'temperatureBatteryStatus', 'rangeStatus'})
             else:
-                vehicle.odometer._set_value(None)  # pylint: disable=protected-access
+                LOG.warning('No measurements data available for vehicle %s', vin)
+                LOG.debug('Full data dump: %s', json.dumps(data))
 
             if 'exteriorStatus' in data and data['exteriorStatus'] is not None:
                 exterior_status = data['exteriorStatus']


### PR DESCRIPTION
i am missing the odometer entry from MQTT.

i can see it in the logs
```
2026-01-05T16:22:22-0500:carconnectivity.connectors.volkswagen:DEBUG:connector:+===== Setting Odometer to 161967 km
2026-01-05T16:22:22-0500:carconnectivity.connectors.volkswagen:DEBUG:connector:Captured_at timezone info: UTC
2026-01-05T16:22:22-0500:carconnectivity.connectors.volkswagen:DEBUG:connector:Last captured timezone info: UTC
```

but then further down i see this one 
```
2026-01-05T16:10:14-0500:carconnectivity.plugins.mqtt:DEBUG:mqtt_client:carconnectivity/0/garage/WVGTMPE25MP023898/odometer, value is disabled
```
which makes me think that the odometer field is being reset. in the code i see this branch does reset it for some reason? seems the code branch is refering to the temp/fuel branch so if thats unavaialbe not sure why odometer resets.

added some logs to this branch of the code in place of just setting odometer to None


https://github.com/tillsteinbach/CarConnectivity-plugin-mqtt_homeassistant/issues/45



not sure if there is way to test this locally on my hass install? as this is nested inside the CarConnectivity Addon? 