### PR TITLE
add auto increment workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ name: Build Python Package
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ main ]
+    branches: [ main, beta ]
     tags:
       - "v*"
     paths:
@@ -57,6 +57,34 @@ jobs:
 #    - name: Test
 #      run: |
 #        make test
+    - name: Auto-increment version tag and publish
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta')
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        
+        # Get latest tag
+        latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+        latest_tag=${latest_tag#v}  # Remove 'v' prefix
+        
+        # Parse version
+        IFS='.' read -r major minor patch <<< "$latest_tag"
+        
+        # Increment version based on branch
+        if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+          # Main: increment patch for stable release
+          patch=$((patch + 1))
+          new_tag="v${major}.${minor}.${patch}"
+        else
+          # Beta: append beta identifier
+          beta_num=$(git tag -l "v${major}.${minor}.${patch}-beta*" | wc -l)
+          beta_num=$((beta_num + 1))
+          new_tag="v${major}.${minor}.${patch}-beta.${beta_num}"
+        fi
+        
+        # Create and push tag
+        git tag -a "$new_tag" -m "Release $new_tag"
+        git push origin "$new_tag"
 
 
 


### PR DESCRIPTION
Extended the workflow to support automatic tagging. 

also added support for beta versions, when you push changes to the "beta" this workflow will trigger and add a tag  `v1.0.0-beta.1` the new tag will trigger the build_and_publish.yml which will then publish beta version to pypi

i use the homeassistant pacakge by pulpyyy
https://github.com/Pulpyyyy/carconnectivity-addon/tree/main/carconnectivity-addon-edge


this should allow developement to contiue on the beta branch which will get pulled by the `-edge` addon keeping the main package stable for other uses while we test things here. 

let me know if this approach doesnt make sense or you dont like it. 

cheers