### PR TITLE
fix(SPIN): Use country-specific TSP value

### DIFF
--- a/src/carconnectivity_connectors/volkswagen_na/connector.py
+++ b/src/carconnectivity_connectors/volkswagen_na/connector.py
@@ -2060,7 +2060,9 @@ class Connector(BaseConnector):
                 return None
             verify_string = challenge_string + "." + spin
             verify_hash = hashlib.sha512(verify_string.encode("ascii")).hexdigest()
-            verify_data = {"idToken": self.session.id_token, "spinHash": verify_hash, "tsp": "WCT"}
+            # Use country-specific TSP
+            tsp = "ATC" if self.session.country == "ca" else "WCT"
+            verify_data = {"idToken": self.session.id_token, "spinHash": verify_hash, "tsp": tsp}
             verify_response: requests.Response = self.session.post(verify_url, data=json.dumps(verify_data), allow_redirects=True, access_type=AccessType.ID)
             if verify_response.status_code != requests.codes["ok"]:
                 LOG.error("Could not execute spin verify (%s: %s)", verify_response.status_code, verify_response.text)


### PR DESCRIPTION
Fixes #57

The TSP (Telematics Service Provider) parameter used in the SPIN session request for Canadian users is `ATC` instead of `WCT`

Based on HTTP logs of the myVW Canadian app.