### PR TITLE
fix(auth): Use access_token for SPIN + request full OAuth scopes

### DIFF
--- a/src/carconnectivity_connectors/volkswagen_na/auth/myvw_session.py
+++ b/src/carconnectivity_connectors/volkswagen_na/auth/myvw_session.py
@@ -44,7 +44,7 @@ class MyVWSession(VWWebSession):
         super(MyVWSession, self).__init__(
             client_id=client_id,
             refresh_url=f"https://b-h-s.spr.{country}00.p.con-veh.net/oidc/v1/token",
-            scope="openid",
+            scope="openid profile cars vin",
             redirect_uri="kombi:///login",
             state=None,
             session_user=session_user,
@@ -114,7 +114,7 @@ class MyVWSession(VWWebSession):
         # self.verifier, self.challenge = pkce.generate_pkce_pair(code_verifier_length=64)
         params: list[Tuple[str, str]] = [
             (("redirect_uri", self.redirect_uri)),
-            (("scope", "openid")),
+            (("scope", "openid profile cars vin")),
             (("prompt", "login")),
             (("code_challenge", self.challenge)),
             (("state", self.state)),

--- a/src/carconnectivity_connectors/volkswagen_na/connector.py
+++ b/src/carconnectivity_connectors/volkswagen_na/connector.py
@@ -1985,7 +1985,7 @@ class Connector(BaseConnector):
         url = self.base_url + f"/ss/v1/user/{self.session.user_id}/spin"
         payload = {"spin": spin}
         try:
-            result = self.session.post(url, data=json.dumps(payload), allow_redirects=True, access_type=AccessType.ID)
+            result = self.session.post(url, data=json.dumps(payload), allow_redirects=True, access_type=AccessType.ACCESS)
             print(str(result.text))
             return True
         except HTTPError as http_error:
@@ -2014,7 +2014,7 @@ class Connector(BaseConnector):
         verify_url = self.base_url + f"/ss/v1/user/{self.session.user_id}/vehicle/{vehicle.uuid.value}/session"
         try:
             try:
-                challenge_response: requests.Response = self.session.get(challenge_url, access_type=AccessType.ID)
+                challenge_response: requests.Response = self.session.get(challenge_url, access_type=AccessType.ACCESS)
             except HTTPError as http_error:
                 http_status = _get_http_status_code(http_error)
                 LOG.debug("HTTPError in __do_spin challenge: status_code=%s, response=%s, err=%s", http_status, http_error.response, str(http_error))
@@ -2025,7 +2025,7 @@ class Connector(BaseConnector):
                     except (AuthenticationError, Exception):
                         self.session.login()
                     try:
-                        challenge_response = self.session.get(challenge_url, access_type=AccessType.ID)
+                        challenge_response = self.session.get(challenge_url, access_type=AccessType.ACCESS)
                     except HTTPError as retry_error:
                         LOG.error("SPIN challenge retry also failed: %s", str(retry_error))
                         return None
@@ -2035,7 +2035,7 @@ class Connector(BaseConnector):
                         LOG.warning("SPIN challenge endpoint not found, but set_spin is enabled, trying to set SPIN. Error was: " + resp_text)
                         if not self.__do_set_spin(vehicle, spin):
                             return None
-                        challenge_response = self.session.get(challenge_url, access_type=AccessType.ID)
+                        challenge_response = self.session.get(challenge_url, access_type=AccessType.ACCESS)
                     else:
                         resp_text = http_error.response.text if http_error.response is not None else "no response body"
                         LOG.warning("SPIN challenge endpoint not found: " + resp_text)
@@ -2046,7 +2046,7 @@ class Connector(BaseConnector):
                         LOG.warning("SPIN challenge endpoint forbidden, but set_spin is enabled, trying to set SPIN. Error was: " + resp_text)
                         if not self.__do_set_spin(vehicle, spin):
                             return None
-                        challenge_response = self.session.get(challenge_url, access_type=AccessType.ID)
+                        challenge_response = self.session.get(challenge_url, access_type=AccessType.ACCESS)
                     else:
                         resp_text = http_error.response.text if http_error.response is not None else "no response body"
                         LOG.warning("SPIN challenge endpoint forbidden: " + resp_text)
@@ -2063,7 +2063,7 @@ class Connector(BaseConnector):
             # Use country-specific TSP
             tsp = "ATC" if self.session.country == "ca" else "WCT"
             verify_data = {"idToken": self.session.id_token, "spinHash": verify_hash, "tsp": tsp}
-            verify_response: requests.Response = self.session.post(verify_url, data=json.dumps(verify_data), allow_redirects=True, access_type=AccessType.ID)
+            verify_response: requests.Response = self.session.post(verify_url, data=json.dumps(verify_data), allow_redirects=True, access_type=AccessType.ACCESS)
             if verify_response.status_code != requests.codes["ok"]:
                 LOG.error("Could not execute spin verify (%s: %s)", verify_response.status_code, verify_response.text)
                 return None

--- a/src/carconnectivity_connectors/volkswagen_na/connector.py
+++ b/src/carconnectivity_connectors/volkswagen_na/connector.py
@@ -2063,7 +2063,9 @@ class Connector(BaseConnector):
             # Use country-specific TSP
             tsp = "ATC" if self.session.country == "ca" else "WCT"
             verify_data = {"idToken": self.session.id_token, "spinHash": verify_hash, "tsp": tsp}
-            verify_response: requests.Response = self.session.post(verify_url, data=json.dumps(verify_data), allow_redirects=True, access_type=AccessType.ACCESS)
+            verify_response: requests.Response = self.session.post(
+                verify_url, data=json.dumps(verify_data), allow_redirects=True, access_type=AccessType.ACCESS
+            )
             if verify_response.status_code != requests.codes["ok"]:
                 LOG.error("Could not execute spin verify (%s: %s)", verify_response.status_code, verify_response.text)
                 return None


### PR DESCRIPTION
## Summary

Two fixes for the 401/403 errors affecting NA (US & Canadian) myVW accounts:

### 1. SPIN AccessType fix
VW changed their SPIN service to require `access_token` (instead of `id_token`) as the Bearer token. This modifies 6 instances across `__do_set_spin`, SPIN challenge, and SPIN verify from `AccessType.ID` to `AccessType.ACCESS`.

### 2. OAuth scope fix (NEW)
VW recently tightened token validation on their NA API. The connector was requesting only `scope="openid"`, which per OIDC spec yields a minimal access_token valid only for the UserInfo endpoint. VW now rejects these tokens on resource API calls (403) and SPIN challenges (401).

This changes the OAuth scope to `"openid profile cars vin"` in both the session constructor and the `authorization_url` params, matching the scopes used by the EU connector.

## Testing

Both fixes confirmed working on a Canadian myVW account with two vehicles (2025 ID.Buzz and 2025 Atlas). Vehicle status, SOC, battery range, odometer, GPS, and HVAC data all flowing correctly after the fix.

## Important
After applying this fix, users must **delete their token cache** (`carconnectivity.cache` and `carconnectivity.token`) and restart the connector to force a fresh login with the new scopes.

Fixes #59, #60, #66

Credit to @kjohannessen for identifying the original SPIN issue.