### PR TITLE
Skip SPIN challenge when SPIN:ALL capability is NOT_APPLICABLE (Canada fix)

### DIFF
--- a/src/carconnectivity_connectors/volkswagen_na/connector.py
+++ b/src/carconnectivity_connectors/volkswagen_na/connector.py
@@ -1995,6 +1995,20 @@ class Connector(BaseConnector):
     def __do_spin(self, vehicle: VolkswagenNAVehicle, spin: str | None = None) -> str | None:  # pylint: disable=unused-private-member
         if not isinstance(vehicle, VolkswagenNAVehicle):
             raise CommandError("Object is not a VolkswagenNAVehicle")
+        # Some accounts/regions (notably myVW Canada) report SPIN:ALL capability with
+        # status NOT_APPLICABLE. Attempting the SPIN challenge in that case yields a
+        # 401 from /ss/v1/user/{id}/challenge and triggers needless re-auth churn.
+        # Skip the SPIN flow entirely when the capability is not applicable.
+        if vehicle.capabilities.has_capability("SPIN:ALL"):
+            spin_capability = vehicle.capabilities.get_capability("SPIN:ALL")
+            if (
+                spin_capability is not None
+                and spin_capability.status.enabled
+                and spin_capability.status.value is not None
+                and Capability.Status.NOT_APPLICABLE in spin_capability.status.value
+            ):
+                LOG.debug("SPIN:ALL capability is NOT_APPLICABLE for vehicle %s, skipping SPIN challenge", vehicle.vin)
+                return None
         LOG.debug("Checking for cached spin token: %s, expires at %s", vehicle.spin_token, vehicle.spin_token_expiry)
         # Use a 120-second buffer for SPIN token expiry to match the access token buffer
         spin_expiry_buffer = timedelta(seconds=120)


### PR DESCRIPTION
# Skip SPIN challenge when SPIN:ALL capability is NOT_APPLICABLE

## What this fixes

When configuring the connector with `country: ca` for Canadian VW accounts, the connector currently fails with `401 Unauthorized` errors when it tries to fetch a SPIN token via `POST /ss/v1/user/{user_id}/challenge`.

Investigation showed that for Canadian accounts, the vehicle's `SPIN:ALL` capability is reported by VW with status `NOT_APPLICABLE`, indicating that the SPIN/PIN flow is not used in this region. Despite this, the connector still attempts the SPIN challenge, resulting in 401 spam in logs and failed status fetches whenever a SPIN-protected endpoint is touched.

## What this changes

In `__do_spin()` in `connector.py`, before attempting the SPIN challenge, check whether the vehicle has the `SPIN:ALL` capability and, if so, whether its status is `Capability.Status.NOT_APPLICABLE`. If it is, return `None` immediately without attempting the challenge.

The change is 14 lines and gated entirely by an existing capability already declared by VW's API. All call sites of `__do_spin()` already handle a `None` return value.

## Verification

Tested on:
- 2024 VW Tiguan, Canadian myVW account, `country: ca`
- Connector deployed standalone via Docker against MQTT bridge to Home Assistant

After patch:
- No more `POST /ss/v1/user/.../challenge -> 401` entries in logs
- MQTT bridge healthy
- Vehicle entities published successfully
- Vehicle metadata (VIN, model, image) populates correctly in Home Assistant

## Notes for reviewers

- This patch does not address the separate `403 Forbidden` issue on `GET /rvs/v1/vehicle/{id}` for Canadian accounts (see linked issue) — that is an unrelated downstream problem.
- US accounts are unaffected: their `SPIN:ALL` capability has a different status and the early-return doesn't trigger.

## Patch

Branch: `fix-canada-spin-not-applicable` on `B-Gomes/CarConnectivity-connector-volkswagen-na`