### PR TITLE
Fix charging current crash and misleading slider

### DIFF
--- a/src/carconnectivity_connectors/volkswagen_na/connector.py
+++ b/src/carconnectivity_connectors/volkswagen_na/connector.py
@@ -1490,9 +1490,9 @@ class Connector(BaseConnector):
                             charging_settings["maxChargingCurrent"] = 32.0
                         else:
                             charging_settings["maxChargingCurrent"] = 10.0
-                        vehicle.charging.settings.maximum_current.minimum = 6.0
+                        vehicle.charging.settings.maximum_current.minimum = 10.0
                         vehicle.charging.settings.maximum_current.maximum = 32.0
-                        vehicle.charging.settings.maximum_current.precision = 1.0
+                        vehicle.charging.settings.maximum_current.precision = 22.0
                         # pylint: disable-next=protected-access
                         vehicle.charging.settings.maximum_current._add_on_set_hook(self.__on_charging_settings_change)
                         vehicle.charging.settings.maximum_current._is_changeable = True  # pylint: disable=protected-access
@@ -2219,6 +2219,8 @@ class Connector(BaseConnector):
             raise SetterError(f"Timeout during read: {timeout_error}") from timeout_error
         except requests.exceptions.RetryError as retry_error:
             raise SetterError(f"Retrying failed: {retry_error}") from retry_error
+        except HTTPError as http_error:
+            raise SetterError(f"HTTP error setting charging settings: {http_error}") from http_error
         return value
 
     def __on_window_heating_start_stop(


### PR DESCRIPTION
## Summary

Fixes #68 — setting charging current to non-standard values crashes the MQTT thread.

The VW NA API only accepts `"reduced"` (10A) or `"max"` (32A) for `maxChargingCurrent`. Two issues are addressed:

1. **Missing HTTPError handler**: `session.put()` calls `raise_for_status()` which throws `HTTPError` on 403/401 responses. This exception was not caught in the charging settings try/except block, causing the unhandled error to crash the MQTT thread. Added `except HTTPError` to convert it to a `SetterError` (consistent with all other setter methods in the connector).

2. **Misleading slider constraints**: `min=6, max=32, precision=1` presented a continuous 6–32A slider, suggesting any integer amperage was valid. Changed to `min=10, max=32, precision=22` so only the two actually valid values (10A and 32A) are selectable in the HA frontend.

## Test plan

- [x] Deployed to running HA addon via container patching, connector came up healthy
- [x] Force update confirmed correct state mapping (10.0A for "reduced")
- [ ] Verify setting charging current to 10A and 32A still works via HA UI
- [ ] Verify invalid values no longer crash the MQTT thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)