### PR TITLE
Fix SPIN hash: uppercase hex output for SHA-512

### DIFF
--- a/src/carconnectivity_connectors/volkswagen_na/connector.py
+++ b/src/carconnectivity_connectors/volkswagen_na/connector.py
@@ -1996,9 +1996,9 @@ class Connector(BaseConnector):
         if not isinstance(vehicle, VolkswagenNAVehicle):
             raise CommandError("Object is not a VolkswagenNAVehicle")
         # Some accounts/regions (notably myVW Canada) report SPIN:ALL capability with
-        # status NOT_APPLICABLE. Attempting the SPIN challenge in that case yields a
-        # 401 from /ss/v1/user/{id}/challenge and triggers needless re-auth churn.
-        # Skip the SPIN flow entirely when the capability is not applicable.
+        # status NOT_APPLICABLE, but SPIN actually works for these vehicles.
+        # Log it as informational and proceed with the SPIN flow regardless.
+        # See: https://github.com/zackcornelius/CarConnectivity-connector-volkswagen-na/issues/66
         if vehicle.capabilities.has_capability("SPIN:ALL"):
             spin_capability = vehicle.capabilities.get_capability("SPIN:ALL")
             if (
@@ -2007,8 +2007,7 @@ class Connector(BaseConnector):
                 and spin_capability.status.value is not None
                 and Capability.Status.NOT_APPLICABLE in spin_capability.status.value
             ):
-                LOG.debug("SPIN:ALL capability is NOT_APPLICABLE for vehicle %s, skipping SPIN challenge", vehicle.vin)
-                return None
+                LOG.info("SPIN:ALL capability reports NOT_APPLICABLE for vehicle %s, but proceeding with SPIN challenge anyway", vehicle.vin)
         LOG.debug("Checking for cached spin token: %s, expires at %s", vehicle.spin_token, vehicle.spin_token_expiry)
         # Use a 120-second buffer for SPIN token expiry to match the access token buffer
         spin_expiry_buffer = timedelta(seconds=120)
@@ -2075,7 +2074,7 @@ class Connector(BaseConnector):
             verify_string = challenge_string + "." + spin
             verify_hash = hashlib.sha512(verify_string.encode("utf-8")).hexdigest().upper()
             # Use country-specific TSP
-            tsp = "ATC" if self.session.country == "ca" else "WCT"
+            tsp = "WCT"
             verify_data = {"idToken": self.session.id_token, "spinHash": verify_hash, "tsp": tsp}
             verify_response: requests.Response = self.session.post(
                 verify_url, data=json.dumps(verify_data), allow_redirects=True, access_type=AccessType.ACCESS

--- a/src/carconnectivity_connectors/volkswagen_na/connector.py
+++ b/src/carconnectivity_connectors/volkswagen_na/connector.py
@@ -2073,7 +2073,7 @@ class Connector(BaseConnector):
                 LOG.warning(f"Skipping SPIN token fetching, only {challenge_response_data['data']['remainingTries']} tries remaining")
                 return None
             verify_string = challenge_string + "." + spin
-            verify_hash = hashlib.sha512(verify_string.encode("ascii")).hexdigest()
+            verify_hash = hashlib.sha512(verify_string.encode("utf-8")).hexdigest().upper()
             # Use country-specific TSP
             tsp = "ATC" if self.session.country == "ca" else "WCT"
             verify_data = {"idToken": self.session.id_token, "spinHash": verify_hash, "tsp": tsp}


### PR DESCRIPTION
## Summary

Three fixes for Canadian myVW accounts (and potentially other regions) that were preventing SPIN authentication and vehicle data access.

### Fix 1: SPIN hash must be uppercase hex (c59e71c)
- `hashlib.sha512(...).hexdigest().upper()` — the myVW Android app (confirmed via APK decompilation of v6.7.0) outputs uppercase hex for the SHA-512 SPIN hash. The server rejects lowercase.
- Also switched encoding from `ascii` to `utf-8` for broader character support.

### Fix 2: Use WCT as TSP for all regions (33e78e7)
- The previous code used `"ATC"` (Aeris) for `country=="ca"`, but both MEB (ID.Buzz) and non-MEB (Atlas) Canadian vehicles use WirelessCar (`"WCT"`).
- Using `"ATC"` caused SPIN verification to fail silently.

### Fix 3: Don't skip SPIN for NOT_APPLICABLE capability (33e78e7)
- Canadian accounts report `SPIN:ALL` capability as `NOT_APPLICABLE`, but SPIN actually works for these vehicles.
- The early `return None` was silently preventing all vehicle data access — without the `carnetVehicleToken` JWT from SPIN, vehicle endpoints return 403.
- Changed to log at INFO level and proceed with the SPIN challenge.
- Relates to #66

### Testing
Tested with two Canadian vehicles:
- 2025 ID.Buzz (MEB platform) — full data access confirmed
- 2024 Atlas (non-MEB) — full data access confirmed

Both vehicles work with `tsp = "WCT"` and uppercase SPIN hash.
