### PR TITLE
fix: set climate settings as changeable before firing ENABLED event

### DIFF
--- a/src/carconnectivity_connectors/volkswagen_na/connector.py
+++ b/src/carconnectivity_connectors/volkswagen_na/connector.py
@@ -1114,16 +1114,13 @@ class Connector(BaseConnector):
                             else:
                                 LOG_API.info("Unknown unitInCar %s", climatization_settings["targetTemperature"]["unit"])
                         target_temperature: float = climatization_settings["targetTemperature"]["temperature"]
-                        if preferred_unit == Temperature.C:
-                            min_temperature: Optional[float] = 16
-                            max_temperature: Optional[float] = 29.5
-                        elif preferred_unit == Temperature.F:
-                            min_temperature: Optional[float] = 61
-                            max_temperature: Optional[float] = 85
-                        else:
-                            min_temperature: Optional[float] = None
-                            max_temperature: Optional[float] = None
-                        LOG.debug("Updating target temperature to %s %s", target_temperature, preferred_unit.value)
+                        # Normalize to Celsius for consistent internal representation
+                        if preferred_unit == Temperature.F:
+                            target_temperature = round((target_temperature - 32) * 5 / 9, 1)
+                        # Always use Celsius for min/max so HA bridge displays them correctly
+                        min_temperature: Optional[float] = 16.0
+                        max_temperature: Optional[float] = 29.5
+                        LOG.debug("Updating target temperature to %s °C (API unit: %s)", target_temperature, preferred_unit.value)
                         # pylint: disable-next=protected-access
                         vehicle.climatization.settings.target_temperature._add_on_set_hook(self.__on_air_conditioning_settings_change)
                         vehicle.climatization.settings.target_temperature._is_changeable = True  # pylint: disable=protected-access
@@ -1131,7 +1128,7 @@ class Connector(BaseConnector):
                             vehicle.climatization.settings.target_temperature,
                             target_temperature,
                             captured_at,
-                            unit=preferred_unit,
+                            unit=Temperature.C,
                         )
                         vehicle.climatization.settings.target_temperature.minimum = min_temperature
                         vehicle.climatization.settings.target_temperature.maximum = max_temperature
@@ -1777,9 +1774,16 @@ class Connector(BaseConnector):
             precision: float = settings.target_temperature.precision if settings.target_temperature.precision is not None else 0.5
             if isinstance(attribute, TemperatureAttribute) and attribute.id == "target_temperature":
                 value = round(value / precision) * precision
+                # Convert from internal Celsius to car's native unit for the API
+                if settings.unit_in_car == Temperature.F:
+                    value = round((value * 9 / 5 + 32) / precision) * precision
                 setting_dict["targetTemperature"]["temperature"] = value
             else:
-                setting_dict["targetTemperature"]["temperature"] = round(settings.target_temperature.value / precision) * precision
+                api_temp: float = round(settings.target_temperature.value / precision) * precision
+                # Convert from internal Celsius to car's native unit for the API
+                if settings.unit_in_car == Temperature.F:
+                    api_temp = round((api_temp * 9 / 5 + 32) / precision) * precision
+                setting_dict["targetTemperature"]["temperature"] = api_temp
             setting_dict["targetTemperature"]["measurementState"] = "valid"
             if settings.unit_in_car == Temperature.C:
                 setting_dict["targetTemperature"]["unit"] = "celsius"

--- a/src/carconnectivity_connectors/volkswagen_na/connector.py
+++ b/src/carconnectivity_connectors/volkswagen_na/connector.py
@@ -1124,6 +1124,9 @@ class Connector(BaseConnector):
                             min_temperature: Optional[float] = None
                             max_temperature: Optional[float] = None
                         LOG.debug("Updating target temperature to %s %s", target_temperature, preferred_unit.value)
+                        # pylint: disable-next=protected-access
+                        vehicle.climatization.settings.target_temperature._add_on_set_hook(self.__on_air_conditioning_settings_change)
+                        vehicle.climatization.settings.target_temperature._is_changeable = True  # pylint: disable=protected-access
                         self.update_float(
                             vehicle.climatization.settings.target_temperature,
                             target_temperature,
@@ -1133,21 +1136,18 @@ class Connector(BaseConnector):
                         vehicle.climatization.settings.target_temperature.minimum = min_temperature
                         vehicle.climatization.settings.target_temperature.maximum = max_temperature
                         vehicle.climatization.settings.target_temperature.precision = precision
-                        # pylint: disable-next=protected-access
-                        vehicle.climatization.settings.target_temperature._add_on_set_hook(self.__on_air_conditioning_settings_change)
-                        vehicle.climatization.settings.target_temperature._is_changeable = True  # pylint: disable=protected-access
                     if (
                         "climatizationWithoutExternalPower" in climatization_settings
                         and climatization_settings["climatizationWithoutExternalPower"] is not None
                     ):
+                        # pylint: disable-next=protected-access
+                        vehicle.climatization.settings.climatization_without_external_power._add_on_set_hook(self.__on_air_conditioning_settings_change)
+                        vehicle.climatization.settings.climatization_without_external_power._is_changeable = True  # pylint: disable=protected-access
                         self.update_boolean(
                             vehicle.climatization.settings.climatization_without_external_power,
                             climatization_settings["climatizationWithoutExternalPower"],
                             captured_at,
                         )
-                        # pylint: disable-next=protected-access
-                        vehicle.climatization.settings.climatization_without_external_power._add_on_set_hook(self.__on_air_conditioning_settings_change)
-                        vehicle.climatization.settings.climatization_without_external_power._is_changeable = True  # pylint: disable=protected-access
                     else:
                         self.update_boolean(
                             vehicle.climatization.settings.climatization_without_external_power,
@@ -1167,48 +1167,48 @@ class Connector(BaseConnector):
                         and "climatizationAtUnlock" in climatization_element_settings
                         and climatization_element_settings["climatizationAtUnlock"] is not None
                     ):
-                        self.update_boolean(
-                            vehicle.climatization.settings.climatization_at_unlock, climatization_element_settings["climatizationAtUnlock"], captured_at
-                        )
                         # pylint: disable-next=protected-access
                         vehicle.climatization.settings.climatization_at_unlock._add_on_set_hook(self.__on_air_conditioning_settings_change)
                         vehicle.climatization.settings.climatization_at_unlock._is_changeable = True  # pylint: disable=protected-access
+                        self.update_boolean(
+                            vehicle.climatization.settings.climatization_at_unlock, climatization_element_settings["climatizationAtUnlock"], captured_at
+                        )
                     else:
                         self.update_boolean(vehicle.climatization.settings.climatization_at_unlock, None, captured_at)
                     if "windowHeatingEnabled" in climatization_element_settings and climatization_element_settings["windowHeatingEnabled"] is not None:
-                        self.update_boolean(vehicle.climatization.settings.window_heating, climatization_element_settings["windowHeatingEnabled"], captured_at)
                         # pylint: disable-next=protected-access
                         vehicle.climatization.settings.window_heating._add_on_set_hook(self.__on_air_conditioning_settings_change)
                         vehicle.climatization.settings.window_heating._is_changeable = True  # pylint: disable=protected-access
+                        self.update_boolean(vehicle.climatization.settings.window_heating, climatization_element_settings["windowHeatingEnabled"], captured_at)
                     else:
                         self.update_boolean(vehicle.climatization.settings.window_heating, None, captured_at)
                     if "zoneFrontLeftEnabled" in climatization_element_settings and climatization_element_settings["zoneFrontLeftEnabled"] is not None:
-                        self.update_boolean(vclimatesettings.front_zone_left_enabled, climatization_element_settings["zoneFrontLeftEnabled"], captured_at)
                         # pylint: disable-next=protected-access
                         vclimatesettings.front_zone_left_enabled._add_on_set_hook(self.__on_air_conditioning_settings_change)
                         vclimatesettings.front_zone_left_enabled._is_changeable = True  # pylint: disable=protected-access
+                        self.update_boolean(vclimatesettings.front_zone_left_enabled, climatization_element_settings["zoneFrontLeftEnabled"], captured_at)
                     else:
                         self.update_boolean(vclimatesettings.front_zone_left_enabled, None, captured_at)
                     if "zoneFrontRightEnabled" in climatization_element_settings and climatization_element_settings["zoneFrontRightEnabled"] is not None:
-                        self.update_boolean(vclimatesettings.front_zone_right_enabled, climatization_element_settings["zoneFrontRightEnabled"], captured_at)
                         # pylint: disable-next=protected-access
                         vclimatesettings.front_zone_right_enabled._add_on_set_hook(self.__on_air_conditioning_settings_change)
                         vclimatesettings.front_zone_right_enabled._is_changeable = True  # pylint: disable=protected-access
+                        self.update_boolean(vclimatesettings.front_zone_right_enabled, climatization_element_settings["zoneFrontRightEnabled"], captured_at)
                     else:
                         self.update_boolean(vclimatesettings.front_zone_right_enabled, None, captured_at)
                     if "zoneRearLeftEnabled" in climatization_element_settings and climatization_element_settings["zoneRearLeftEnabled"] is not None:
-                        self.update_boolean(vclimatesettings.rear_zone_left_enabled, climatization_element_settings["zoneRearLeftEnabled"], captured_at)
                         # pylint: disable-next=protected-access
                         vclimatesettings.rear_zone_left_enabled._add_on_set_hook(self.__on_air_conditioning_settings_change)
                         vclimatesettings.rear_zone_left_enabled._is_changeable = True  # pylint: disable=protected-access
+                        self.update_boolean(vclimatesettings.rear_zone_left_enabled, climatization_element_settings["zoneRearLeftEnabled"], captured_at)
                     else:
                         # pylint: disable-next=protected-access
                         self.update_boolean(vclimatesettings.rear_zone_left_enabled, None, captured_at)
                     if "zoneRearRightEnabled" in climatization_element_settings and climatization_element_settings["zoneRearRightEnabled"] is not None:
-                        self.update_boolean(vclimatesettings.rear_zone_right_enabled, climatization_element_settings["zoneRearRightEnabled"], captured_at)
                         # pylint: disable-next=protected-access
                         vclimatesettings.rear_zone_right_enabled._add_on_set_hook(self.__on_air_conditioning_settings_change)
                         vclimatesettings.rear_zone_right_enabled._is_changeable = True  # pylint: disable=protected-access
+                        self.update_boolean(vclimatesettings.rear_zone_right_enabled, climatization_element_settings["zoneRearRightEnabled"], captured_at)
                     else:
                         self.update_boolean(vclimatesettings.rear_zone_right_enabled, None, captured_at)
                     if (


### PR DESCRIPTION
### Problem

Climate settings (target temperature, zone enables, window heating, etc.) cannot be changed via MQTT or Home Assistant. Start/stop climatization works fine, but adjusting settings like temperature is silently ignored.

### Root Cause

In `connector.py`, the climate settings attributes set `_is_changeable = True` and add the `on_set_hook` **after** calling `update_float()`/`update_boolean()`. These update calls fire the `ENABLED` event, and the MQTT bridge checks `is_changeable` during that event to decide whether to subscribe to the write topic. Since `_is_changeable` is still `False` at that point, the bridge never subscribes, making climate settings read-only via MQTT/Home Assistant.

This is a race condition in the initialization order. Commands (start/stop) work correctly because `GenericCommand.__init__` sets `_is_changeable = True` **before** any events fire.

### Fix

Move `_add_on_set_hook()` and `_is_changeable = True` **before** the `update_float()`/`update_boolean()` calls for all 8 affected attributes:

- `target_temperature`
- `climatization_without_external_power`
- `climatization_at_unlock`
- `window_heating`
- `front_zone_left_enabled`
- `front_zone_right_enabled`
- `rear_zone_left_enabled`
- `rear_zone_right_enabled`

### Testing

Tested on a 2025 VW ID. Buzz (Canadian account, VW NA connector v0.1.22) with the CarConnectivity HA addon. After applying the fix:

- Temperature correctly displays in Home Assistant (previously showed "low"/15)
- `climate.set_temperature` successfully changes the temperature via the VW API
- ABRP telemetry confirms the new setpoint is applied

cc @zackcornelius