### PR TITLE
fix(auth): send play_integrity_token on token grants (VW change 2026-07-30)

### DIFF
--- a/src/carconnectivity_connectors/volkswagen_na/auth/myvw_session.py
+++ b/src/carconnectivity_connectors/volkswagen_na/auth/myvw_session.py
@@ -67,6 +67,9 @@ class MyVWSession(VWWebSession):
     # myVW Android app version; bump if VW starts rejecting it.
     APP_VERSION: str = "2026.5.27-9076"
 
+    # Required on both token grants since 2026-07-30; VW checks presence, not validity.
+    PLAY_INTEGRITY_TOKEN: str = "unavailable"
+
     def _app_headers(self, content_type: str) -> Dict[str, str]:
         """Headers the myVW Android app sends on its API/token calls."""
         return {
@@ -183,6 +186,7 @@ class MyVWSession(VWWebSession):
         query = parse_qs(url.query)
 
         token_data = {
+            "play_integrity_token": self.PLAY_INTEGRITY_TOKEN,
             "grant_type": "authorization_code",
             "code": query["code"][0],
             "client_id": self.client_id,
@@ -291,7 +295,17 @@ class MyVWSession(VWWebSession):
         if headers is None:
             headers = self._app_headers("application/x-www-form-urlencoded")
 
-        data = {"grant_type": "refresh_token", "client_id": self.client_id, "code_verifier": self.verifier, "refresh_token": self.refresh_token}
+        # VW rejects the refresh grant with 400 unless the original login's verifier is replayed.
+        if not self.verifier:
+            raise AuthenticationError("Refreshing tokens failed: no code_verifier stored for this session, new authorization required")
+
+        data = {
+            "play_integrity_token": self.PLAY_INTEGRITY_TOKEN,
+            "grant_type": "refresh_token",
+            "client_id": self.client_id,
+            "code_verifier": self.verifier,
+            "refresh_token": self.refresh_token,
+        }
 
         # Request new tokens using the refresh token
         try:


### PR DESCRIPTION
## Problem

Since 2026-07-30 the NA backend rejects every token request with a bare `401`:

```
requests.exceptions.HTTPError: 401 Client Error:  for url: https://b-h-s.spr.us00.p.con-veh.net/oidc/v1/token
carconnectivity.errors.AuthenticationError: Refreshing tokens failed: Server requests new authorization
```

Both grants are affected, so refresh fails, the fallback full login fails at the code
exchange, and the background thread dies with `Critical error during update`. The web
signin itself still succeeds — an authorization code is issued, it just cannot be
exchanged.

## Root cause

VW added a `play_integrity_token` field to the `/oidc/v1/token` grants. The stock myVW
app sends a Google Play Integrity verdict; the endpoint currently checks only that the
field is **present**, not that it is valid, so a placeholder is accepted.

A second, related change: the refresh grant is now tied to the PKCE verifier from the
original login and fails without it:

```json
{"error":{"errorCode":"INVALID_REQUEST","errorDescription":"Invalid Request",
 "origin":"CarnetSPAuthorizationServer","path":"/azs",
 "reason":"Internal Service validation failure","statusCode":"400 BAD_REQUEST"}}
```

`SessionManager` already persists `verifier` alongside the token, so this works out of
the box — but a token store written before that support existed has none, and the
resulting 400 is not worth a round trip to discover.

## Changes (`auth/myvw_session.py`)

- Add `PLAY_INTEGRITY_TOKEN` (placeholder `"unavailable"`) to the `authorization_code`
  and `refresh_token` grant bodies. Kept as a named constant next to `APP_VERSION`,
  since it is the first thing to revisit if VW starts validating it.
- Raise `AuthenticationError` from `refresh_tokens` when no verifier is stored, so
  `OpenIDSession` goes straight to a full login instead of spending a request to learn
  the same thing.

15 lines added, no behaviour change to anything else.

## What is *not* changed, and why

Vehicle-scoped reads also began returning `403 USER_NOT_AUTHORIZED` on 2026-07-30:

```
GET /rvs/v1/vehicle/{uuid}  ->  403 {"errorCode":"USER_NOT_AUTHORIZED","origin":"vehiclestatusservice"}
```

They now require a `carnetVehicleToken` rather than a plain access token. **The
connector already does this** — `__do_spin()` mints and caches one per vehicle, and
`fetch_vehicle_status()` passes it to `/rvs` and to the `/ev` climate and charge
summaries via `_fetch_data(token=…)`. That machinery (added for the earlier Canada
403s) turns out to be exactly what VW now requires everywhere, so no change was needed.
It only ever looked broken because auth failed first and it never got to run.

Worth recording since it came up while investigating: the uppercase hex S-PIN challenge
hash from #71 is confirmed correct against the live backend. Other implementations
document lowercase; uppercase is what works.

Accounts without an S-PIN configured cannot poll vehicle status at all after this VW
change, regardless of this PR.

## Testing

- Verified live against the US backend: login, refresh with the verifier replayed,
  refresh after a simulated restart-from-cache, the fail-fast path, and the garage read
  all succeed. `/rvs` returns 403 with a plain access token and 200 with a
  `carnetVehicleToken`.
- Running in Home Assistant since; vehicle entities update normally again.
- US only — CA is parameterised identically but I have no CA account to confirm with.

## Note

`play_integrity_token: "unavailable"` is a stopgap that depends on VW not validating
the attestation. A real Play Integrity verdict cannot be minted off-device, so if they
begin checking it this approach stops working and there is no server-side remedy.
