### PR TITLE
fix(auth): use backend-local 'sub' as user id on CA endpoints

### DIFF
--- a/src/carconnectivity_connectors/volkswagen_na/auth/openid_session.py
+++ b/src/carconnectivity_connectors/volkswagen_na/auth/openid_session.py
@@ -294,6 +294,33 @@ class OpenIDSession(requests.Session):
             return self.metadata["userId"]
         return None
 
+    @property
+    def backend_user_id(self):
+        """
+        Retrieve the backend-local user ID from the access token's 'sub' claim.
+
+        On the CA backend (ca00), the 'userId' from the login redirect (stored in
+        self.user_id / metadata['userId']) is the global IDP-level SSO ID (ssoid).
+        However, the SpinService and RRS endpoints on ca00 require the backend-local
+        subject identifier, which is the 'sub' claim in the access token JWT.
+
+        These are two different values on ca00, which makes every request that
+        embeds the user id in its path fail with 403 USER_NOT_AUTHORIZED.
+
+        Falls back to self.user_id if the access token is unavailable or cannot
+        be decoded, preserving behaviour on the US backend where both values are
+        the same.
+        """
+        if self.access_token is not None:
+            try:
+                payload = jwt.decode(self.access_token, options={"verify_signature": False})
+                sub = payload.get("sub")
+                if sub:
+                    return sub
+            except Exception:  # pylint: disable=broad-except
+                pass
+        return self.user_id
+
     @user_id.setter
     def user_id(self, new_user_id):
         """

--- a/src/carconnectivity_connectors/volkswagen_na/auth/openid_session.py
+++ b/src/carconnectivity_connectors/volkswagen_na/auth/openid_session.py
@@ -317,8 +317,8 @@ class OpenIDSession(requests.Session):
                 sub = payload.get("sub")
                 if sub:
                     return sub
-            except Exception:  # pylint: disable=broad-except
-                pass
+            except (jwt.PyJWTError, TypeError, ValueError) as decode_error:
+                LOG.debug("Could not read 'sub' from access token, falling back to user_id: %s", decode_error)
         return self.user_id
 
     @user_id.setter

--- a/src/carconnectivity_connectors/volkswagen_na/connector.py
+++ b/src/carconnectivity_connectors/volkswagen_na/connector.py
@@ -464,7 +464,7 @@ class Connector(BaseConnector):
                         else:
                             vehicle.model._set_value(None)  # pylint: disable=protected-access
 
-                        rrs_url = self.base_url + f"/rrs/v1/privileges/user/{self.session.user_id}/vehicle/{vehicle.uuid.value}"
+                        rrs_url = self.base_url + f"/rrs/v1/privileges/user/{self.session.backend_user_id}/vehicle/{vehicle.uuid.value}"
                         try:
                             rrs_response = self.session.get(rrs_url)
                             rrs_data = rrs_response.json()
@@ -1986,7 +1986,7 @@ class Connector(BaseConnector):
                 LOG.warning("S-PIN is missing, please add S-PIN to your configuration or .netrc file")
                 return False
             spin = self.active_config["spin"]
-        url = self.base_url + f"/ss/v1/user/{self.session.user_id}/spin"
+        url = self.base_url + f"/ss/v1/user/{self.session.backend_user_id}/spin"
         payload = {"spin": spin}
         try:
             result = self.session.post(url, data=json.dumps(payload), allow_redirects=True, access_type=AccessType.ACCESS)
@@ -2027,8 +2027,8 @@ class Connector(BaseConnector):
                 LOG.warning("S-PIN is missing, please add S-PIN to your configuration or .netrc file")
                 return None
             spin = self.active_config["spin"]
-        challenge_url = self.base_url + f"/ss/v1/user/{self.session.user_id}/challenge"
-        verify_url = self.base_url + f"/ss/v1/user/{self.session.user_id}/vehicle/{vehicle.uuid.value}/session"
+        challenge_url = self.base_url + f"/ss/v1/user/{self.session.backend_user_id}/challenge"
+        verify_url = self.base_url + f"/ss/v1/user/{self.session.backend_user_id}/vehicle/{vehicle.uuid.value}/session"
         try:
             try:
                 challenge_response: requests.Response = self.session.get(challenge_url, access_type=AccessType.ACCESS)


### PR DESCRIPTION
Fixes #86. Revives #76 by @marcantoinet, which was closed a minute after it was opened and never merged — the analysis there is theirs.

## Problem

On `ca00`, `metadata['userId']` from the login redirect is the IDP-level SSO id (ssoid), but the SpinService and RRS endpoints expect the backend-local subject identifier — the `sub` claim of the access token. The two differ on `ca00` and are identical on `us00`.

Result: every request embedding the user id in its path returns 403 `USER_NOT_AUTHORIZED`, while login and `/account/v1/garage` (no user id in path) succeed. So the connector authenticates, discovers the vehicle, and then fails to read anything — and the SPIN challenge 403 is a symptom, not the cause.

## Change

Adds `OpenIDSession.backend_user_id`, which decodes the access token and returns `sub`, falling back to `user_id` when the token is missing or undecodable. Four call sites now use it:

- `/rrs/v1/privileges/user/{id}/vehicle/{uuid}`
- `/ss/v1/user/{id}/challenge`
- `/ss/v1/user/{id}/vehicle/{uuid}/session`
- `/ss/v1/user/{id}/spin`

`us00` is unaffected: both values resolve to the same id, and the fallback preserves current behaviour if the token cannot be read. `jwt` was already imported in `openid_session.py`; no new dependency.

## Verification

Canadian 2023 ID.4, myVW CA, connector 0.1.24 on the HA add-on (edge).

**Before** — every vehicle endpoint 403:
```
WARNING:connector:SPIN challenge endpoint forbidden: {"errorCode":"USER_NOT_AUTHORIZED", ... "origin":"SpinService","path":"/ss"}
ERROR:connector:Retry after 403 also failed for vin <VIN>
```

**After** — no 403s, no warnings, data populates:
```
id4 Odometer ........ 62522.0 km
id4 SoC (primary) ... 37.0 %
id4 Total Range ..... 258.0 km
id4 Vehicle State ... parked
Connector Connection State = connected
```
50 of 54 entities live, and SoC/range update across polls.

Tested by patching the installed package in the running add-on container, so the diff is exactly what ran.

## Not addressed here

`tsp` is still hardcoded to `"WCT"` beneath a `# Use country-specific TSP` comment — #58 set `ATC` for CA and 33e78e7 reverted it, leaving the comment orphaned. Left alone deliberately to keep this PR to one concern; noted in #86. It was unreachable on `ca00` until now, so it may surface once this lands.
