### PR TITLE
feat: PI token relay support + remote engine start/stop for ICE/hybrid vehicles

### DIFF
--- a/src/carconnectivity_connectors/volkswagen_na/auth/myvw_session.py
+++ b/src/carconnectivity_connectors/volkswagen_na/auth/myvw_session.py
@@ -67,8 +67,17 @@ class MyVWSession(VWWebSession):
     # myVW Android app version; bump if VW starts rejecting it.
     APP_VERSION: str = "2026.5.27-9076"
 
-    # Required on both token grants since 2026-07-30; VW checks presence, not validity.
+    # Required on both token grants since 2026-07-30; VW checks presence, not validity (CA).
+    # US endpoint validates the token — use set_play_integrity_token() to supply a real one
+    # from an external relay.
     PLAY_INTEGRITY_TOKEN: str = "unavailable"
+
+    def set_play_integrity_token(self, token: str) -> None:
+        """Update the Play Integrity token used in token grant requests.
+        Called by the connector when a relay supplies a real PI token via MQTT."""
+        if token and token != "unavailable":
+            self.PLAY_INTEGRITY_TOKEN = token
+            LOG.info("Play Integrity token updated (len=%d)", len(token))
 
     def _app_headers(self, content_type: str) -> Dict[str, str]:
         """Headers the myVW Android app sends on its API/token calls."""

--- a/src/carconnectivity_connectors/volkswagen_na/auth/myvw_session.py
+++ b/src/carconnectivity_connectors/volkswagen_na/auth/myvw_session.py
@@ -75,7 +75,7 @@ class MyVWSession(VWWebSession):
     def set_play_integrity_token(self, token: str) -> None:
         """Update the Play Integrity token used in token grant requests.
         Called by the connector when a relay supplies a real PI token via MQTT."""
-        if token and token != "unavailable":
+        if token and token != "unavailable":  # nosec B105 — not a password, sentinel for "no PI token"
             self.PLAY_INTEGRITY_TOKEN = token
             LOG.info("Play Integrity token updated (len=%d)", len(token))
 

--- a/src/carconnectivity_connectors/volkswagen_na/command_impl.py
+++ b/src/carconnectivity_connectors/volkswagen_na/command_impl.py
@@ -76,3 +76,71 @@ class SpinCommand(GenericCommand):
 
         def __str__(self) -> str:
             return self.value
+
+
+class RemoteStartCommand(GenericCommand):
+    """
+    RemoteStartCommand is a command class for remote engine start/stop (RST).
+
+    This is used for ICE/hybrid vehicles with TSP="ATC" (Aeris telematics).
+    The command triggers a two-challenge SPIN verification flow followed by
+    a POST (start) or DELETE (stop) to the rst/v1 endpoint.
+
+    Protocol (from myVW APK decompilation):
+      1. GET challenge → compute spinHash (SHA-512 of "{challenge}.{spin}", uppercase hex)
+      2. POST session with spinHash + idToken + tsp → ATC carnetVehicleToken
+      3. GET second challenge (challenges are single-use)
+      4. POST climateControl/check with spinHash → roToken
+      5. POST rst/v1/vehicle/{vehicleId} with roToken (start) or DELETE (stop)
+    """
+
+    def __init__(self, name: str = "remote-start", parent: Optional[GenericObject] = None, initialization: Optional[Dict] = None) -> None:
+        super().__init__(name=name, parent=parent, initialization=initialization)
+
+    @property
+    def value(self) -> Optional[Union[str, Dict]]:
+        return super().value
+
+    @value.setter
+    def value(self, new_value: Optional[Union[str, Dict]]) -> None:
+        new_value = self._execute_on_set_hook(new_value, early_hook=True)
+        if isinstance(new_value, RemoteStartCommand.Command):
+            newvalue_dict = {}
+            newvalue_dict["command"] = new_value
+            new_value = newvalue_dict
+        elif isinstance(new_value, str):
+            parser = ThrowingArgumentParser(prog="", add_help=False, exit_on_error=False)
+            parser.add_argument("command", help="Command to execute", type=RemoteStartCommand.Command, choices=list(RemoteStartCommand.Command))
+            try:
+                args = parser.parse_args(new_value.strip().split(sep=" "))
+            except argparse.ArgumentError as e:
+                raise SetterError(f"Invalid format for RemoteStartCommand: {e.message} {parser.format_usage()}") from e
+            newvalue_dict = {}
+            newvalue_dict["command"] = args.command
+            new_value = newvalue_dict
+        elif isinstance(new_value, dict):
+            if "command" in new_value and isinstance(new_value["command"], str):
+                if new_value["command"] in RemoteStartCommand.Command:
+                    new_value["command"] = RemoteStartCommand.Command(new_value["command"])
+                else:
+                    raise ValueError(f"Invalid value for RemoteStartCommand. Command must be one of {RemoteStartCommand.Command}")
+        if self._is_changeable:
+            new_value = self._execute_on_set_hook(new_value, early_hook=False)
+            self._set_value(new_value)
+        else:
+            raise TypeError("You cannot use this command. Command is not implemented.")
+
+    class Command(Enum):
+        """
+        Enum class representing remote start commands.
+
+        Attributes:
+            START: Start the engine remotely.
+            STOP: Stop the engine remotely.
+        """
+
+        START = "start"
+        STOP = "stop"
+
+        def __str__(self) -> str:
+            return self.value

--- a/src/carconnectivity_connectors/volkswagen_na/connector.py
+++ b/src/carconnectivity_connectors/volkswagen_na/connector.py
@@ -1505,9 +1505,9 @@ class Connector(BaseConnector):
                             charging_settings["maxChargingCurrent"] = 32.0
                         else:
                             charging_settings["maxChargingCurrent"] = 10.0
-                        vehicle.charging.settings.maximum_current.minimum = 6.0
+                        vehicle.charging.settings.maximum_current.minimum = 10.0
                         vehicle.charging.settings.maximum_current.maximum = 32.0
-                        vehicle.charging.settings.maximum_current.precision = 1.0
+                        vehicle.charging.settings.maximum_current.precision = 22.0
                         # pylint: disable-next=protected-access
                         vehicle.charging.settings.maximum_current._add_on_set_hook(self.__on_charging_settings_change)
                         vehicle.charging.settings.maximum_current._is_changeable = True  # pylint: disable=protected-access

--- a/src/carconnectivity_connectors/volkswagen_na/connector.py
+++ b/src/carconnectivity_connectors/volkswagen_na/connector.py
@@ -67,6 +67,7 @@ from carconnectivity_connectors.volkswagen_na.auth.session_manager import Sessio
 from carconnectivity_connectors.volkswagen_na.auth.myvw_session import MyVWSession
 from carconnectivity_connectors.volkswagen_na.auth.openid_session import AccessType
 from carconnectivity_connectors.volkswagen_na.vehicle import VolkswagenNAVehicle, VolkswagenNAElectricVehicle, VolkswagenNACombustionVehicle
+from carconnectivity_connectors.volkswagen_na.command_impl import RemoteStartCommand
 from carconnectivity_connectors.volkswagen_na.climatization import VolkswagenClimatization
 from carconnectivity_connectors.volkswagen_na.capability import Capability
 from carconnectivity_connectors.volkswagen_na._version import __version__
@@ -477,6 +478,17 @@ class Connector(BaseConnector):
                             rrs_data
                             and "data" in rrs_data
                             and rrs_data["data"] is not None
+                        ):
+                            # Extract TSP (Telematics Service Provider) for this vehicle.
+                            # "WCT" = WirelessCar (MEB/EV platform), "ATC" = Aeris (ICE/Atlas platform).
+                            if "tsp" in rrs_data["data"]:
+                                vehicle.tsp = rrs_data["data"]["tsp"]
+                                LOG.debug("Vehicle %s TSP: %s", vehicle.vin, vehicle.tsp)
+
+                        if (
+                            rrs_data
+                            and "data" in rrs_data
+                            and rrs_data["data"] is not None
                             and "services" in rrs_data["data"]
                             and rrs_data["data"]["services"] is not None
                         ):
@@ -546,6 +558,16 @@ class Connector(BaseConnector):
                                 lock_unlock_command._add_on_set_hook(self.__on_lock_unlock)  # pylint: disable=protected-access
                                 lock_unlock_command.enabled = True
                                 vehicle.doors.commands.add_command(lock_unlock_command)
+
+                        # Add remote start command for ICE/hybrid vehicles with RST capability
+                        has_remote_start: bool = vehicle.capabilities.has_capability("RemoteStart:ALL", check_status_ok=True)
+                        LOG.debug("Vehicle %s has remote start capability: %s (tsp=%s)", vehicle.vin, has_remote_start, getattr(vehicle, 'tsp', None))
+                        if has_remote_start:
+                            if vehicle.commands is not None and vehicle.commands.commands is not None and not vehicle.commands.contains_command("remote-start"):
+                                remote_start_command = RemoteStartCommand(parent=vehicle.commands)
+                                remote_start_command._add_on_set_hook(self.__on_remote_start_stop)  # pylint: disable=protected-access
+                                remote_start_command.enabled = True
+                                vehicle.commands.add_command(remote_start_command)
 
                         if SUPPORT_IMAGES:
                             # fetch vehcile images
@@ -1487,9 +1509,9 @@ class Connector(BaseConnector):
                             charging_settings["maxChargingCurrent"] = 32.0
                         else:
                             charging_settings["maxChargingCurrent"] = 10.0
-                        vehicle.charging.settings.maximum_current.minimum = 10.0
+                        vehicle.charging.settings.maximum_current.minimum = 6.0
                         vehicle.charging.settings.maximum_current.maximum = 32.0
-                        vehicle.charging.settings.maximum_current.precision = 22.0
+                        vehicle.charging.settings.maximum_current.precision = 1.0
                         # pylint: disable-next=protected-access
                         vehicle.charging.settings.maximum_current._add_on_set_hook(self.__on_charging_settings_change)
                         vehicle.charging.settings.maximum_current._is_changeable = True  # pylint: disable=protected-access
@@ -1848,6 +1870,141 @@ class Connector(BaseConnector):
             raise SetterError(f"Retrying failed: {retry_error}") from retry_error
         return value
 
+    def __get_ro_token(self, vehicle: VolkswagenNAVehicle) -> tuple:
+        """
+        Obtain a Remote Operation (RO) token for RST (Remote Start) commands.
+
+        Implements a two-challenge flow specific to ATC (Aeris/ICE) vehicles:
+          1. Fetch challenge1 → compute spinHash1 → POST session → get ATC carnetVehicleToken
+          2. Fetch challenge2 → compute spinHash2 → POST climateControl/check → get roToken
+
+        Each challenge is single-use. The session endpoint consumes challenge1,
+        so we must fetch a second challenge for climateControl/check.
+
+        Returns:
+            Tuple of (atc_token, ro_token).
+
+        Raises:
+            CommandError: If any step fails.
+        """
+        spin = self.active_config.get("spin")
+        if not spin:
+            raise CommandError("S-PIN is required for remote start. Add it to your configuration or .netrc file.")
+
+        vuuid = vehicle.uuid.value
+        if vuuid is None:
+            raise CommandError("Vehicle UUID is missing")
+
+        challenge_url = self.base_url + f"/ss/v1/user/{self.session.backend_user_id}/challenge"
+        session_url = self.base_url + f"/ss/v1/user/{self.session.backend_user_id}/vehicle/{vuuid}/session"
+        check_url = self.base_url + f"/ss/v1/user/{self.session.backend_user_id}/vehicle/{vuuid}/operation/climateControl/check"
+
+        tsp = vehicle.tsp or "WCT"
+
+        # Step 1: First challenge → ATC session token
+        LOG.debug("RST: Fetching challenge1 for ATC session")
+        challenge1_response = self.session.get(challenge_url, access_type=AccessType.ACCESS)
+        challenge1_data = challenge1_response.json()
+        challenge1 = challenge1_data["data"]["challenge"]
+        remaining = challenge1_data["data"].get("remainingTries", 999)
+        if remaining < 3:
+            raise CommandError(f"RST: Only {remaining} SPIN tries remaining, aborting for safety")
+
+        spin_hash1 = hashlib.sha512(f"{challenge1}.{spin}".encode("utf-8")).hexdigest().upper()
+        session_body = {"idToken": self.session.id_token, "spinHash": spin_hash1, "tsp": tsp}
+        LOG.debug("RST: Posting ATC session request (tsp=%s)", tsp)
+        session_response = self.session.post(session_url, data=json.dumps(session_body), allow_redirects=True, access_type=AccessType.ACCESS)
+        if session_response.status_code != requests.codes["ok"]:
+            raise CommandError(f"RST: ATC session request failed ({session_response.status_code}: {session_response.text})")
+
+        atc_token = session_response.json()["data"]["carnetVehicleToken"]
+        LOG.debug("RST: Got ATC carnetVehicleToken")
+
+        # Step 2: Second challenge → climateControl/check → roToken
+        LOG.debug("RST: Fetching challenge2 for climateControl/check")
+        challenge2_response = self.session.get(challenge_url, access_type=AccessType.ACCESS)
+        challenge2_data = challenge2_response.json()
+        challenge2 = challenge2_data["data"]["challenge"]
+
+        spin_hash2 = hashlib.sha512(f"{challenge2}.{spin}".encode("utf-8")).hexdigest().upper()
+        check_body = {"spinHash": spin_hash2}
+        LOG.debug("RST: Posting climateControl/check for roToken")
+        check_response = self.session.post(check_url, data=json.dumps(check_body), allow_redirects=True, token=atc_token)
+        if check_response.status_code != requests.codes["ok"]:
+            raise CommandError(f"RST: climateControl/check failed ({check_response.status_code}: {check_response.text})")
+
+        ro_token = check_response.json()["data"]["roToken"]
+        LOG.debug("RST: Got roToken (length=%d)", len(ro_token))
+
+        vehicle.spin_token = atc_token
+        try:
+            data = jwt.decode(atc_token, options={"verify_signature": False})
+            vehicle.spin_token_expiry = datetime.fromtimestamp(data["exp"], tz=timezone.utc)
+        except Exception:
+            vehicle.spin_token_expiry = None
+
+        return atc_token, ro_token
+
+    def __on_remote_start_stop(
+        self, remote_start_command: RemoteStartCommand, command_arguments: Union[str, Dict[str, Any]]
+    ) -> Union[str, Dict[str, Any]]:
+        """Handle remote engine start/stop command for ICE/hybrid vehicles."""
+        if (
+            remote_start_command.parent is None
+            or remote_start_command.parent.parent is None
+            or not isinstance(remote_start_command.parent.parent, VolkswagenNAVehicle)
+        ):
+            raise CommandError("Object hierarchy is not as expected")
+        if not isinstance(command_arguments, dict):
+            raise CommandError("Command arguments are not a dictionary")
+
+        vehicle: VolkswagenNAVehicle = remote_start_command.parent.parent
+        vin: Optional[str] = vehicle.vin.value
+        vuuid: Optional[str] = vehicle.uuid.value
+        if vin is None:
+            raise CommandError("VIN in object hierarchy missing")
+        if vuuid is None:
+            raise CommandError("UUID in object hierarchy missing")
+        if "command" not in command_arguments:
+            raise CommandError("Command argument missing")
+
+        rst_url = self.base_url + f"/rst/v1/vehicle/{vuuid}"
+
+        try:
+            atc_token, ro_token = self.__get_ro_token(vehicle)
+
+            if command_arguments["command"] == RemoteStartCommand.Command.START:
+                LOG.info("RST: Starting engine for vehicle %s", vin)
+                rst_body = {"roToken": ro_token}
+                command_response: requests.Response = self.session.post(
+                    rst_url, data=json.dumps(rst_body), allow_redirects=True, token=atc_token
+                )
+            elif command_arguments["command"] == RemoteStartCommand.Command.STOP:
+                LOG.info("RST: Stopping engine for vehicle %s", vin)
+                command_response = self.session.delete(rst_url, allow_redirects=True, token=atc_token)
+            else:
+                raise CommandError(f"Unknown remote start command: {command_arguments['command']}")
+
+            if command_response.status_code != requests.codes["ok"]:
+                LOG.error("RST: Command failed (%s: %s)", command_response.status_code, command_response.text)
+                raise CommandError(f"Remote start command failed ({command_response.status_code}: {command_response.text})")
+
+            response_data = command_response.json()
+            correlation_id = response_data.get("correlationId")
+            LOG.info("RST: Command accepted, correlationId=%s", correlation_id)
+
+        except requests.exceptions.ConnectionError as connection_error:
+            raise CommandError(
+                f"Connection error: {connection_error}. If this happens frequently, please check if other applications communicate with the Volkswagen server."
+            ) from connection_error
+        except requests.exceptions.ChunkedEncodingError as chunked_encoding_error:
+            raise CommandError(f"Error: {chunked_encoding_error}") from chunked_encoding_error
+        except requests.exceptions.ReadTimeout as timeout_error:
+            raise CommandError(f"Timeout during read: {timeout_error}") from timeout_error
+        except requests.exceptions.RetryError as retry_error:
+            raise CommandError(f"Retrying failed: {retry_error}") from retry_error
+        return command_arguments
+
     def __on_air_conditioning_start_stop(
         self, start_stop_command: ClimatizationStartStopCommand, command_arguments: Union[str, Dict[str, Any]]
     ) -> Union[str, Dict[str, Any]]:
@@ -2077,8 +2234,9 @@ class Connector(BaseConnector):
                 return None
             verify_string = challenge_string + "." + spin
             verify_hash = hashlib.sha512(verify_string.encode("utf-8")).hexdigest().upper()
-            # Use country-specific TSP
-            tsp = "WCT"
+            # Use vehicle-specific TSP from RRS data.
+            # "WCT" = WirelessCar (MEB/EV), "ATC" = Aeris (ICE, e.g. Atlas).
+            tsp = vehicle.tsp or "WCT"
             verify_data = {"idToken": self.session.id_token, "spinHash": verify_hash, "tsp": tsp}
             verify_response: requests.Response = self.session.post(
                 verify_url, data=json.dumps(verify_data), allow_redirects=True, access_type=AccessType.ACCESS

--- a/src/carconnectivity_connectors/volkswagen_na/connector.py
+++ b/src/carconnectivity_connectors/volkswagen_na/connector.py
@@ -219,6 +219,10 @@ class Connector(BaseConnector):
         self.session.retries = 3
         self.session.timeout = 180
 
+        # Accept a Play Integrity token from config (e.g. relayed from an external source)
+        if "play_integrity_token" in config and config["play_integrity_token"]:
+            self.session.set_play_integrity_token(config["play_integrity_token"])
+
         self._elapsed: List[timedelta] = []
 
     def startup(self) -> None:

--- a/src/carconnectivity_connectors/volkswagen_na/connector.py
+++ b/src/carconnectivity_connectors/volkswagen_na/connector.py
@@ -474,11 +474,7 @@ class Connector(BaseConnector):
                             LOG.error("Error fetching RRS data for vehicle %s: %s", vehicle.vin, str(err))
                             rrs_data = None
 
-                        if (
-                            rrs_data
-                            and "data" in rrs_data
-                            and rrs_data["data"] is not None
-                        ):
+                        if rrs_data and "data" in rrs_data and rrs_data["data"] is not None:
                             # Extract TSP (Telematics Service Provider) for this vehicle.
                             # "WCT" = WirelessCar (MEB/EV platform), "ATC" = Aeris (ICE/Atlas platform).
                             if "tsp" in rrs_data["data"]:
@@ -561,7 +557,7 @@ class Connector(BaseConnector):
 
                         # Add remote start command for ICE/hybrid vehicles with RST capability
                         has_remote_start: bool = vehicle.capabilities.has_capability("RemoteStart:ALL", check_status_ok=True)
-                        LOG.debug("Vehicle %s has remote start capability: %s (tsp=%s)", vehicle.vin, has_remote_start, getattr(vehicle, 'tsp', None))
+                        LOG.debug("Vehicle %s has remote start capability: %s (tsp=%s)", vehicle.vin, has_remote_start, getattr(vehicle, "tsp", None))
                         if has_remote_start:
                             if vehicle.commands is not None and vehicle.commands.commands is not None and not vehicle.commands.contains_command("remote-start"):
                                 remote_start_command = RemoteStartCommand(parent=vehicle.commands)
@@ -1945,9 +1941,7 @@ class Connector(BaseConnector):
 
         return atc_token, ro_token
 
-    def __on_remote_start_stop(
-        self, remote_start_command: RemoteStartCommand, command_arguments: Union[str, Dict[str, Any]]
-    ) -> Union[str, Dict[str, Any]]:
+    def __on_remote_start_stop(self, remote_start_command: RemoteStartCommand, command_arguments: Union[str, Dict[str, Any]]) -> Union[str, Dict[str, Any]]:
         """Handle remote engine start/stop command for ICE/hybrid vehicles."""
         if (
             remote_start_command.parent is None
@@ -1976,9 +1970,7 @@ class Connector(BaseConnector):
             if command_arguments["command"] == RemoteStartCommand.Command.START:
                 LOG.info("RST: Starting engine for vehicle %s", vin)
                 rst_body = {"roToken": ro_token}
-                command_response: requests.Response = self.session.post(
-                    rst_url, data=json.dumps(rst_body), allow_redirects=True, token=atc_token
-                )
+                command_response: requests.Response = self.session.post(rst_url, data=json.dumps(rst_body), allow_redirects=True, token=atc_token)
             elif command_arguments["command"] == RemoteStartCommand.Command.STOP:
                 LOG.info("RST: Stopping engine for vehicle %s", vin)
                 command_response = self.session.delete(rst_url, allow_redirects=True, token=atc_token)

--- a/src/carconnectivity_connectors/volkswagen_na/vehicle.py
+++ b/src/carconnectivity_connectors/volkswagen_na/vehicle.py
@@ -40,6 +40,7 @@ class VolkswagenNAVehicle(GenericVehicle):  # pylint: disable=too-many-instance-
 
     spin_token: Optional[str] = None
     spin_token_expiry: Optional[datetime] = None
+    tsp: Optional[str] = None  # Telematics Service Provider: "WCT" (WirelessCar/MEB) or "ATC" (Aeris/ICE)
 
     def __init__(
         self,
@@ -59,6 +60,7 @@ class VolkswagenNAVehicle(GenericVehicle):  # pylint: disable=too-many-instance-
             self.uuid.parent = self
             self.spin_token = origin.spin_token
             self.spin_token_expiry = origin.spin_token_expiry
+            self.tsp = origin.tsp
             if SUPPORT_IMAGES:
                 self._car_images = origin._car_images
         else:


### PR DESCRIPTION
## Summary

Enables the VW NA connector to work with Play Integrity–attested tokens supplied by an external relay (e.g. a rooted Android phone running the real myVW app + Frida). PI enforcement is currently active in the US and expected to roll out to Canada.

**Important finding:** The Canadian endpoint (`b-h-s.spr.ca00.p.con-veh.net`) **does** receive real Play Integrity tokens from the myVW app (~446–447 bytes), even though it doesn't currently validate them. The app sends PI tokens on every OIDC token grant (both initial login and refresh). This means when VW enforces PI in Canada, the relay approach will already be passing valid tokens.

Tested end-to-end on two vehicles on the Canadian endpoint:
- **2024 Atlas** (ICE, TSP=ATC) — lock, unlock, climate, remote start, vehicle status
- **2025 ID. Buzz** (EV, TSP=WCT) — lock, unlock, climate, charging, vehicle status

US endpoint uses the same API (base URL is region-selectable via `country` config) but is untested.

## Changes

- **Play Integrity token support** — `set_play_integrity_token()` method on session, config option to accept PI tokens from external relay. Sentinel value "unavailable" used when no relay is connected.
- **Vehicle-specific TSP** — extracts TSP from RRS data and stores on vehicle object. Uses it in SPIN verification instead of hardcoded "WCT". This is critical: ATC vehicles (Atlas, Tiguan) fail SPIN verification with the wrong TSP value, breaking lock/unlock/climate on ICE platforms.
- **`RemoteStartCommand`** — new command class with START/STOP for ICE/hybrid vehicles, registered when vehicle has `RemoteStart:ALL` capability. Two-challenge SPIN flow → roToken → POST/DELETE to `/rst/v1/vehicle/{id}`.
- **No auth changes** — all PI token and app header fixes from recent PRs are preserved.

## Protocol notes (from myVW APK decompilation)

- Wire field names: `spinHash` (not `pinHash`), `roToken` in RST body
- SHA-512 hash must be uppercase hex: `SHA-512("{challenge}.{spin}").toUpperCase()`
- TSP: `"ATC"` for ICE (Atlas, Tiguan), `"WCT"` for MEB/EV (ID. Buzz)
- Challenges are single-use — need a fresh one for each step
- Uses `backend_user_id` for all `/ss/v1/user/` URLs (matches PR #87)

## Token relay add-on

A companion [HA add-on](https://github.com/danielsza/ha-vw-token-relay) provides the PI-attested tokens. It runs Frida on a rooted Moto G Pure, hooks the myVW app's OkHttp interceptor, and publishes tokens to MQTT. Includes auto-PIF-recovery (fingerprint update + reboot + screen unlock) when tokens go stale.

### How PI tokens are captured

The Frida hook intercepts OkHttp3's BridgeInterceptor and reads the OIDC token grant POST body using OkHttp's FormBody API (`size()`, `encodedName(i)`, `encodedValue(i)`). This bypasses R8/ProGuard obfuscation of `okio.Buffer` which prevents direct buffer reads. The `play_integrity_token` field is extracted from the URL-encoded form data and published to MQTT.

## Test plan

- [x] Full vehicle data fetch on Atlas (ICE/ATC) with PI-relayed token
- [x] Full vehicle data fetch on ID. Buzz (EV/WCT) with PI-relayed token
- [x] Lock/unlock on both ATC and WCT vehicles
- [x] Climate start/stop on both vehicles
- [x] Remote start on Atlas (ICE/ATC)
- [x] PI token capture confirmed (3 consecutive captures, ~446–447 bytes each)
- [ ] US endpoint testing (should work — same API, different base URL)